### PR TITLE
Now 'FORMAT TabSeparatedWithNamesAndTypes' doesn't break CREATE TABLE

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ class ClickHouse {
 		
 		// 'INSERT INTO t VALUES (1),(2),(3)' || 'SELECT date, count() FROM log WHERE siteId = '123'
 		else if (opts.query && ! opts.body) {
-			if ( ! opts.query.match(/^insert/i)) {
+			if ( ! opts.query.match(/^insert/i) && (!opts.query.match(/^create/i))) {
 				opts.query += ' FORMAT TabSeparatedWithNamesAndTypes';
 			}
 			


### PR DESCRIPTION
Recent version has a bug with CREATE TABLE which are really useful for integration tests. This PR fixes the bug.