### PR TITLE
Support for ALTER query

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ class ClickHouse {
 		
 		// 'INSERT INTO t VALUES (1),(2),(3)' || 'SELECT date, count() FROM log WHERE siteId = '123'
 		else if (opts.query && ! opts.body) {
-			if ( ! opts.query.match(/^insert/i) && (!opts.query.match(/^create/i)) && !opts.query.match(/^drop/i)) {
+			if (!opts.query.match(/^(insert|create|drop|alter)/i)) {
 				opts.query += ' FORMAT TabSeparatedWithNamesAndTypes';
 			}
 			


### PR DESCRIPTION
`ALTER` not compatible with `FORMAT TabSeparatedWithNamesAndTypes`