### PR TITLE
Add execRaw, toPromiseRaw

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,8 +149,11 @@ class QueryCursor {
 		this.opts      = opts;
 	}
 	
-	
 	exec(cb) {
+		this.execRaw(cb, 'data');
+	}
+	
+	execRaw(cb, value) {
 		let me = this;
 		
 		if (me.opts.debug) {
@@ -185,23 +188,29 @@ class QueryCursor {
 			try {
 				let json = JSON.parse(res.body);
 				
-				cb(null, json.data);
+				cb(null, value ? json[value] : json);
 			} catch (err2) {
 				cb(err2);
 			}
 		});
 	}
-	
-	
+
+
 	toPromise() {
+		return this.toPromiseRaw('data');
+	}	
+
+
+	toPromiseRaw(value) {
 		let me = this;
+		const useValue = value;
 		
 		return new Promise((resolve, reject) => {
-			me.exec(function (err, data) {
+			me.execRaw(function (err, data) {
 				if (err) return reject(err);
 				
 				resolve(data);
-			})
+			}, useValue)
 		});
 	}
 	

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   ],
   "name": "clickhouse",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/TimonKK/clickhouse.git"

--- a/test/test.js
+++ b/test/test.js
@@ -188,7 +188,7 @@ describe('queries', () => {
 		
 		const rows = [
 			{
-				date: '1915-01-01',
+				date: '2018-01-01',
 				str: 'Вам, проживающим за оргией оргию,',
 				arr: [],
 				arr2: ['1915-01-02', '1915-01-03'],
@@ -196,7 +196,7 @@ describe('queries', () => {
 			},
 			
 			{
-				date: '1915-02-01',
+				date: '2018-02-01',
 				str: 'имеющим ванную и теплый клозет!',
 				arr: ['5670000000', 'asdas dasf'],
 				arr2: ['1915-02-02'],
@@ -279,6 +279,15 @@ describe('queries', () => {
 		const result9 = await clickhouse.query('SELECT count(*) AS count FROM session_temp').toPromise();
 		const result10 = await clickhouse.query('SELECT count(*) AS count FROM session_temp2').toPromise();
 		expect(result9).to.eql(result10);
+
+		const result11 = await clickhouse.query('SELECT date FROM test.test_array GROUP BY date WITH TOTALS').toPromiseRaw();
+		expect(result11).to.have.key('totals');	
+		expect(result11).to.have.key('data');
+		expect(result11).to.have.key('statistics');
+
+		const result12 = await clickhouse.query('SELECT date, count() AS totals_count FROM test.test_array GROUP BY date WITH TOTALS').toPromiseRaw('totals');
+		expect(result12).to.have.key('totals_count');
+		expect(result12.totals_count).to.have.greaterThan(0);
 	});
 });
 


### PR DESCRIPTION
Добавил методы execRaw, toPromiseRaw, не нарушающие совместимость и позволяющие получить полные данные результата, не только поле `data`. Тесты прилагаются.

Первоначально доработка потребовалась для корректной работы с использованием мотификатора [WITH TOTALS](https://clickhouse.yandex/docs/ru/query_language/select/#with-totals), выдающего результат вида:
```JS
{ meta: [ ... ],
  data: [ ... ],
  totals: { ...},
  rows: 2,
  statistics: { elapsed: 0.0024725, rows_read: 20, bytes_read: 40 } }
```


test:
```
  10 passing (15s)
```