### PR TITLE
Added return-types.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,13 +13,13 @@ declare module 'clickhouse' {
   }
 
   export class WriteStream extends Stream.Transform {
-    writeRow(data: Array<any>);
-    exec();
+    writeRow(data: Array<any>): void;
+    exec(): Promise<{}>;
   }
 
   class QueryCursor {
     toPromise(): Promise<Object[]>;
-    exec(callback: callbackExec);
+    exec(callback: callbackExec): void;
     stream(): Stream | WriteStream;
   }
 }


### PR DESCRIPTION
Added return-types for functions for fix it:
```
node_modules/clickhouse/index.d.ts:16:5 - error TS7010: 'writeRow', which lacks return-type annotation, implicitly has an 'any' return type.

16     writeRow(data: Array<any>);
       ~~~~~~~~

node_modules/clickhouse/index.d.ts:17:5 - error TS7010: 'exec', which lacks return-type annotation, implicitly has an 'any' return type.

17     exec();
       ~~~~

node_modules/clickhouse/index.d.ts:22:5 - error TS7010: 'exec', which lacks return-type annotation, implicitly has an 'any' return type.

22     exec(callback: callbackExec);
       ~~~~
```