### PR TITLE
Add withTotals to type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,8 +18,9 @@ declare module 'clickhouse' {
   }
 
   class QueryCursor {
-    toPromise(): Promise<Object[]>;
+    toPromise(): Promise<any>;
     exec(callback: callbackExec): void;
     stream(): Stream | WriteStream;
+    withTotals(): QueryCursor;
   }
 }


### PR DESCRIPTION
Fixes `Property 'withTotals' does not exist on type 'QueryCursor'.` error when using withTotals with Typescript.

Using withTotals() additionally changes the return type of toPromise() to a single object as opposed to an array of objects, so the return turn is changed from `Promise<Object[]>` to `Promise<any>`