### PR TITLE
Fix return types in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,13 +13,13 @@ declare module 'clickhouse' {
   }
 
   export class WriteStream extends Stream.Transform {
-    writeRow(data: Array<any>): void;
+    writeRow(data: Array<any>): Promise<void>;
     exec(): Promise<{}>;
   }
 
   class QueryCursor {
     toPromise(): Promise<Object[]>;
     exec(callback: callbackExec): void;
-    stream(): Stream | WriteStream;
+    stream(): Stream & WriteStream;
   }
 }


### PR DESCRIPTION
Some minor fixes in index.d.ts to avoid using "ts-ignore".

1. writeRow function of WriteStream always returns Promise
2. stream function of QueryCursor returns Stream OR WriteStream (based on the type of query, select or insert), but currently, it's not possible to describe that in index.d.ts (because in both cases function arguments are the same). That's why I suggest returning "Stream & WriteStream" instead of "Stream | WriteStream".