### PR TITLE
Add tabs to examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ const clickhouse = new ClickHouse({
 	debug: false,
 	basicAuth: null,
 	isUseGzip: false,
-    format: "json", // "json" || "csv" || "tsv"
+	format: "json", // "json" || "csv" || "tsv"
 	config: {
 		session_id                              : 'session_id if neeed',
 		session_timeout                         : 60,
@@ -46,8 +46,8 @@ or change
 to
 
 	basicAuth: {
-	username: 'default',
-	password: '',
+		username: 'default',
+		password: '',
 	},
 
 


### PR DESCRIPTION
Two of the examples in the README where missing tabs for a few lines