### PR TITLE
chore: unify indentation to tab stops

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,8 +124,8 @@ function parseJSONStream() {
 }
 
 function parseTSVStream(s = new Set()) {
-    let isFirst = true;
-    let ref = {
+	let isFirst = true;
+	let ref = {
 		fields: []
 	};
  
@@ -782,7 +782,7 @@ class ClickHouse {
 					output_format_json_quote_64bit_integers : 0,
 					enable_http_compression                 : 0
 				},
-                format: 'json',
+				format: 'json',
 				isSessionPerQuery: false,
 			},
 			opts
@@ -952,6 +952,5 @@ class ClickHouse {
 }
 
 module.exports = {
-    ClickHouse,
+	ClickHouse,
 };
-

--- a/test/test.js
+++ b/test/test.js
@@ -299,8 +299,8 @@ describe('session', () => {
 		
 		clickhouse.sessionId = sessionId;
 	});
-  
-  it('uses session per query', async () => {
+
+	it('uses session per query', async () => {
 		let tempSessionId = `${Date.now()}`;
 		
 		const result = await clickhouse.query(
@@ -313,20 +313,20 @@ describe('session', () => {
 		const result2 = await clickhouse.query(
 			`SELECT * FROM test_table LIMIT 10`, {}, {sessionId: tempSessionId}
 		).toPromise();
-        expect(result2).to.be.ok();
-        try {
-            await clickhouse.query(
-                `SELECT * FROM test_table LIMIT 10`, {}, {sessionId: `${tempSessionId}_bad`}
-            ).toPromise();
-        } catch (error) {
-            expect(error.code).to.be(60);
-        }
-        
-        const result3 = await clickhouse.query(
+		expect(result2).to.be.ok();
+		try {
+			await clickhouse.query(
+				`SELECT * FROM test_table LIMIT 10`, {}, {sessionId: `${tempSessionId}_bad`}
+			).toPromise();
+		} catch (error) {
+			expect(error.code).to.be(60);
+		}
+
+		const result3 = await clickhouse.query(
 			`DROP TEMPORARY TABLE test_table`, {}, {sessionId: tempSessionId}
 		).toPromise();
 		expect(result3).to.be.ok();
-  });
+	});
 
 	it('use setSessionPerQuery #1', async () => {
 		const sessionPerQuery = clickhouse.sessionPerQuery;


### PR DESCRIPTION
The two js files had a couple of places where indentation was using spaces instead of tabs, this PR fixes it so that both files are just using tab stops for indentation.