### PR TITLE
Failing test for #82 on cluster commands do not work

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,14 @@ before(async () => {
 	await temp.query(`CREATE DATABASE ${database}`).toPromise();
 });
 
+describe('On cluster', () => {
+  it('should work', async () => {
+    const query = 'create table test_table on cluster test_shard_localhost (a int) ENGINE=MergeTree;';
+    const r = await clickhouse.query(query).toPromise();
+    expect(r).to.be.ok();
+  });
+});
+
 describe('Exec', () => {
 	it('should return not null object', async () => {
 		const sqlList = [


### PR DESCRIPTION
Failing test for #82.

The body we are getting back is this:
```
localhost       9000    81      Code: 81, e.displayText() = DB::Exception: Database test_93245 doesn\'t exist (version 21.5.6.6 (official build))       0       0
Code: 81, e.displayText() = DB::Exception: There was an error on [localhost:9000]: Code: 81, e.displayText() = DB::Exception: Database test_93245 doesn't exist (version 21.5.6.6 (official build)) (version 21.5.6.6 (official build))
```

I'm not sure why it's saying the database doesn't exist -- might be because my test setup has 2 nodes in a cluster. Regardless, that is not important. What matters here is that `on cluster` causes Clickhouse to send back this tab separated format even though we requested JSON, so we get a parse error.

```
     SyntaxError: Unexpected token l in JSON at position 0
      at parse (<anonymous>)
      at Request._callback (index.js:576:63)
      at Request.self.callback (node_modules/request/request.js:185:22)
      at Request.<anonymous> (node_modules/request/request.js:1161:10)
      at IncomingMessage.<anonymous> (node_modules/request/request.js:1083:12)
      at endReadableNT (_stream_readable.js:1184:12)
      at processTicksAndRejections (internal/process/task_queues.js:80:21)
```