### PR TITLE
Format override, raw stream.

### DIFF
--- a/index.js
+++ b/index.js
@@ -661,7 +661,7 @@ class QueryCursor {
 			me._request = rs;
 			
 			return rs;
-		} else if (me.opts.raw) {
+		} else if (me.opts.raw && me.format !== FORMAT_NAMES.JSON) {
 			const requestStream = request.post(reqParams);
 			
 			let s;

--- a/index.js
+++ b/index.js
@@ -680,6 +680,11 @@ class QueryCursor {
 		}
 
 		if (me.opts.raw) {
+			if (me.format === 'json') {
+				// Only pass through "data" array.
+				s = s.pipe(JSONStream.parse(['data', true])).pipe(JSONStream.stringify());
+			}
+
 			rs.pause  = () => {
 				rs.__pause();
 				requestStream.pause();
@@ -712,7 +717,7 @@ class QueryCursor {
 				cb(null, chunk);
 			};
 			
-			s = s.pipe(tf).pipe(streamParser)
+			s = s.pipe(tf).pipe(streamParser);
 
 			rs.pause  = () => {
 				rs.__pause();

--- a/index.js
+++ b/index.js
@@ -661,6 +661,18 @@ class QueryCursor {
 			me._request = rs;
 			
 			return rs;
+		} else if (me.opts.raw) {
+			const requestStream = request.post(reqParams);
+			
+			let s;
+			if (me.connection.isUseGzip) {
+				const z = zlib.createGunzip();
+				s = requestStream.pipe(z);
+			} else {
+				s = requestStream;
+			}
+
+			return s;
 		} else {
 			const streamParser = this.getStreamParser()();
 			

--- a/index.js
+++ b/index.js
@@ -68,8 +68,7 @@ const USERNAME = 'default';
 const FORMAT_NAMES = {
 	JSON: 'json',
 	TSV: 'tsv',
-	CSV: 'csv',
-	XML: 'xml,'
+	CSV: 'csv'
 }
 
 const FORMATS = {

--- a/index.js
+++ b/index.js
@@ -68,7 +68,8 @@ const USERNAME = 'default';
 const FORMAT_NAMES = {
 	JSON: 'json',
 	TSV: 'tsv',
-	CSV: 'csv'
+	CSV: 'csv',
+	XML: 'xml,'
 }
 
 const FORMATS = {
@@ -651,15 +652,15 @@ class QueryCursor {
 	
 	stream() {
 		const me = this;
-		
+
 		const reqParams = me._getReqParams();
-		
+
 		if (me.isInsert) {
 			const rs = new Rs(reqParams);
 			rs.query = me.query;
-			
+
 			me._request = rs;
-			
+
 			return rs;
 		}
 
@@ -684,23 +685,23 @@ class QueryCursor {
 				rs.__pause();
 				requestStream.pause();
 			};
-			
+
 			rs.resume = () => {
 				rs.__resume();
 				requestStream.resume();
 			};
 		} else {
 			const streamParser = this.getStreamParser()();
-			
+
 			const tf = new Transform({ objectMode: true });
 			let isFirstChunk = true;
 			tf._transform = function (chunk, encoding, cb) {
-				
+
 				// В независимости от формата, в случае ошибки, в теле ответа будет текс,
 				// подпадающий под регулярку R_ERROR.
 				if (isFirstChunk) {
 					isFirstChunk = false;
-					
+
 					if (R_ERROR.test(chunk.toString())) {
 						streamParser.emit('error', new Error(chunk.toString()));
 						rs.emit('close');

--- a/index.js
+++ b/index.js
@@ -352,10 +352,10 @@ class QueryCursor {
 		this.query = query;
 		this.data = data;
 		
-		this.opts = _.merge({}, opts,  {
+		this.opts = _.merge({}, {
 			format: this.connection.opts.format,
 			raw: this.connection.opts.raw
-		});
+		}, opts);
 		
 		// Sometime needs to override format by query
 		const formatFromQuery = ClickHouse.getFormatFromQuery(this.query);


### PR DESCRIPTION
I do exports of data in CSV, TSV and XML. Rather than parse JSON and transform to these other formats, I prefer to have clickhouse output in the desired format.

I need the ability to:

1. Modify the `format` and `raw` options for a single query. Global options are not appropriate as I have queries not related to export within the same project.
2. The `raw` option was ignored in `QueryCursor.stream()` it was only implemented in `QueryCursor.exec()`. I have implemented raw mode for streaming.

I will be sending a PR that adds XML format support shortly.