### PR TITLE
fix(fieldParsing): unable to parse column names with backquote (`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -418,7 +418,7 @@ class QueryCursor {
 		if (isFirstElObject) {
 			let m = query.match(/INSERT INTO (.+?) \((.+?)\)/);
 			if (m) {
-				fieldList = m[2].split(',').map(s => s.trim());
+				fieldList = m[2].split(',').map(s => s.trim().split('`').join(''));
 			} else {
 				throw new Error('insert query wasnt parsed field list after TABLE_NAME');
 			}


### PR DESCRIPTION
if an insert query has column names wrapped with backquotes it will not be able to parse object keys.