### PR TITLE
provide support for on cluster create and drop table queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -492,7 +492,7 @@ class QueryCursor {
 			// Hack for Sequelize ORM
 			query = query.trim().trimEnd().replace(/;$/gm, "");
 			
-			if (query.match(/^(select|show|exists)/i)) {
+			if (query.match(/^(select|show|exists|create)/i)) {
 				if ( ! R_FORMAT_PARSER.test(query)) {
 					query += ` FORMAT ${ClickHouse.getFullFormatName(me.format)}`;
 				}

--- a/index.js
+++ b/index.js
@@ -492,7 +492,7 @@ class QueryCursor {
 			// Hack for Sequelize ORM
 			query = query.trim().trimEnd().replace(/;$/gm, "");
 			
-			if (query.match(/^(select|show|exists|create)/i)) {
+			if (query.match(/^(select|show|exists|create|drop)/i)) {
 				if ( ! R_FORMAT_PARSER.test(query)) {
 					query += ` FORMAT ${ClickHouse.getFullFormatName(me.format)}`;
 				}

--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,19 @@ before(async () => {
 	await temp.query(`CREATE DATABASE ${database}`).toPromise();
 });
 
+describe('On cluster', () => {
+	// Note: this test only works with ClickHouse setup as Cluster named test_cluster
+	it('should be able to create table', async () => {
+		const query = `
+			CREATE TABLE ${database}.test_on_cluster ON CLUSTER test_cluster (
+				test String
+			)
+			ENGINE=MergeTree ORDER BY test;`;
+	  	const r = await clickhouse.query(query).toPromise();
+	  	expect(r).to.be.ok();
+	});
+});
+  
 describe('Exec', () => {
 	it('should return not null object', async () => {
 		const sqlList = [

--- a/test/test.js
+++ b/test/test.js
@@ -36,14 +36,19 @@ before(async () => {
 
 describe('On cluster', () => {
 	// Note: this test only works with ClickHouse setup as Cluster named test_cluster
-	it('should be able to create table', async () => {
-		const query = `
+	it('should be able to create and drop a table', async () => {
+		const createTableQuery = `
 			CREATE TABLE ${database}.test_on_cluster ON CLUSTER test_cluster (
 				test String
 			)
 			ENGINE=MergeTree ORDER BY test;`;
-	  	const r = await clickhouse.query(query).toPromise();
-	  	expect(r).to.be.ok();
+	  	const createTableQueryResult = await clickhouse.query(createTableQuery).toPromise();
+	  	expect(createTableQueryResult).to.be.ok();
+
+		const dropTableQuery = `
+			DROP TABLE ${database}.test_on_cluster ON CLUSTER test_cluster;`;
+	  	const dropTableQueryResult = await clickhouse.query(dropTableQuery).toPromise();
+	  	expect(dropTableQueryResult).to.be.ok();
 	});
 });
   


### PR DESCRIPTION
This PR provides support for queries that run CREATE TABLE and DROP TABLE with ON CLUSTER.

The query throws the following error while trying to parse the server response as JSON:
`SyntaxError: Unexpected token . in JSON at position 5
      at parse (<anonymous>)
      at Request._callback (node_modules/clickhouse/index.js:584:63)
      at Request.self.callback (node_modules/request/request.js:185:22)
      at Request.emit (node:events:390:28)
      at Request.<anonymous> (node_modules/request/request.js:1161:10)
      at Request.emit (node:events:390:28)
      at IncomingMessage.<anonymous> (node_modules/request/request.js:1083:12)
      at Object.onceWrapper (node:events:509:28)
      at IncomingMessage.emit (node:events:402:35)
      at endReadableNT (node:internal/streams/readable:1343:12)
      at processTicksAndRejections (node:internal/process/task_queues:83:21)`

Related to #84 and also I guess should close #82 .