### PR TITLE
Handle stream network error to avoid uncaught error

### DIFF
--- a/index.js
+++ b/index.js
@@ -739,6 +739,11 @@ class QueryCursor {
 			
 			const requestStream = request.post(reqParams);
 			
+			// handle network socket errors to avoid uncaught error
+			requestStream.on('error', function (err) {
+				rs.emit('error', err);
+			});
+
 			// Не делаем .pipe(rs) потому что rs - Readable,
 			// а для pipe нужен Writable
 			let s;

--- a/test/test.js
+++ b/test/test.js
@@ -155,7 +155,9 @@ describe('Select', () => {
 		}).query('SELECT number FROM system.numbers LIMIT 10').stream()
 			.on('data', () => ++i)
 			.on('error', error => {
-				expect(error.message).to.be.equal(`getaddrinfo ENOTFOUND ${host}`);
+				expect(error.code).to.be.equal('ENOTFOUND');
+				expect(error.syscall).to.be.equal('getaddrinfo');
+				expect(error.hostname).to.be.equal(host);
 				expect(i).to.be(0);				
 				callback();
 			});

--- a/test/test.js
+++ b/test/test.js
@@ -144,6 +144,22 @@ describe('Select', () => {
 				callback();
 			})
 	});
+
+	it('streams should handle network error', function(callback) {
+		let i = 0;
+		const host = 'non-existing-clickhouse-server'; // to simulate a dns failure
+
+		new ClickHouse({
+			...config,
+			host
+		}).query('SELECT number FROM system.numbers LIMIT 10').stream()
+			.on('data', () => ++i)
+			.on('error', error => {
+				expect(error.message).to.be.equal(`getaddrinfo ENOTFOUND ${host}`);
+				expect(i).to.be(0);				
+				callback();
+			});
+	});
 	
 	const nodeVersion = process.version.split('.')[0].substr(1);
 	if (parseInt(nodeVersion, 10) >= 10) {


### PR DESCRIPTION
Due to some transient DNS failure our application crashed due to a bug in the **stream()** method that does not handle correctly network error. This issue has been already reported in issue #81 

The following PR add the fix to handling network errors on the stream method. The fix avoid the uncaught error and allow the consumer of the stream method to handle the error.