### PR TITLE
refactor: remove `lodash`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const zlib = require('zlib');
-const _ = require('lodash');
 const request = require('request');
 const { Transform, Readable, } = require('stream');
 const JSONStream = require('JSONStream');
@@ -358,10 +357,10 @@ class QueryCursor {
 		this.query = query;
 		this.data = data;
 		
-		this.opts = _.merge({}, opts,  {
+		this.opts = {...opts,  
 			format: this.connection.opts.format,
 			raw: this.connection.opts.raw
-		});
+		}
 		
 		// Sometime needs to override format by query
 		const formatFromQuery = ClickHouse.getFormatFromQuery(this.query);
@@ -452,15 +451,15 @@ class QueryCursor {
 			database,
 		} = me.connection.opts;
 		
-		const params = _.merge({
+		const params = {
 			headers: {
 				'Content-Type': 'text/plain'
 			},
-		}, reqParams);
+		 ...reqParams};
 		
-		const configQS = _.merge({}, config, {
+		const configQS ={ ...config, 
 			query_id: me.queryId,
-		});
+		};
 		
 		if (me.connection.opts.isSessionPerQuery) {
 			configQS.session_id = uuidv4();
@@ -598,12 +597,13 @@ class QueryCursor {
 		
 		me._request = request.post(reqParams, (err, res) => {
 			if (me.isDebug) {
-				console.log('QueryCursor.exec: result', me.query, err, _.pick(res, [
-					'statusCode',
-					'body',
-					'statusMessage',
-					'headers'
-				]));
+				const { statusCode, body, statusMessage, headers } = res;
+				console.log('QueryCursor.exec: result', me.query, err, {
+					statusCode,
+					body,
+					statusMessage,
+					headers
+				});
 			}
 			
 			if (err) {
@@ -754,10 +754,10 @@ class QueryCursor {
 					rs.emit('error', err);
 				})
 				.on('header', header => {
-					metaData = _.merge({}, header);
+					metaData = header 
 				})
 				.on('footer', footer => {
-					rs.emit('meta', _.merge(metaData, footer));
+					rs.emit('meta', {...metaData, ...footer});
 				})
 				.on('data', function (data) {
 					rs.emit('data', data);
@@ -826,26 +826,25 @@ class QueryCursor {
 
 class ClickHouse {
 	constructor(opts = {}) {
-		this.opts = _.merge(
-			{
-				debug: false,
-				database: DATABASE,
-				password: '',
-				basicAuth: null,
-				isUseGzip: false,
-				config: {
-					session_timeout                         : 60,
-					output_format_json_quote_64bit_integers : 0,
-					enable_http_compression                 : 0
-				},
-				format: FORMAT_NAMES.JSON,
-				raw: false,
-				isSessionPerQuery: false,
-				trimQuery: false,
-				usePost: false,
+		this.opts = {
+			debug: false,
+			database: DATABASE,
+			password: '',
+			basicAuth: null,
+			isUseGzip: false,
+			config: {
+				session_timeout                         : 60,
+				output_format_json_quote_64bit_integers : 0,
+				enable_http_compression                 : 0
 			},
-			opts
-		);
+			format: FORMAT_NAMES.JSON,
+			raw: false,
+			isSessionPerQuery: false,
+			trimQuery: false,
+			usePost: false,
+			...opts
+
+		}
 		
 		
 		let url  = opts.url || opts.host || URI,


### PR DESCRIPTION
# Context
I have noticed that `lodash` is being used in the client and it's making the client unnecessarily heavy because of it's size
<img width="419" alt="image" src="https://user-images.githubusercontent.com/73670999/179215741-0d6e4abc-d3da-443c-9855-d646413bab28.png">

so I removed in `index.js` all the code that uses `lodash` and it's functions and replaced it with normal JavaScript to exclude `lodash`.  

- I replaced `merge` with object spread `{...}`
- I replaced `pick` with ES6 destructuring assignment

> 💡 I haven't removed `lodash` from dependencies  because the test files still use it