### PR TITLE
test enhancement, some bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .idea/*
 .vscode/
 test_config.json
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -199,6 +199,48 @@ const result = await rs.pipe(tf).pipe(ws).exec();
 ```
 ***
 
+insert array of objects:
+```javascript
+
+/*
+	CREATE TABLE IF NOT EXISTS test_array (
+				date Date,
+				str String,
+				arr Array(String),
+				arr2 Array(Date),
+				arr3 Array(UInt8),
+				id1 UUID
+			) ENGINE=MergeTree(date, date, 8192)
+*/
+		const rows = [
+			{
+				date: '2018-01-01',
+				str: 'Something1...',
+				arr: [],
+				arr2: ['1985-01-02', '1985-01-03'],
+				arr3: [1,2,3,4,5],
+				id1: '102a05cb-8aaf-4f11-a442-20c3558e4384'
+			},
+			
+			{
+				date: '2018-02-01',
+				str: 'Something2...',
+				arr: ['5670000000', 'Something3...'],
+				arr2: ['1985-02-02'],
+				arr3: [],
+				id1: 'c2103985-9a1e-4f4a-b288-b292b5209de1'
+			}
+		];
+		
+		await clickhouse.insert(
+			`insert into test_array 
+			(date, str, arr, arr2, 
+			 arr3, id1)`,
+			rows
+		).toPromise();
+```
+***
+
 Parameterized Values:
 ```javascript
 const rows = await clickhouse.query(

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ var ESCAPE_STRING = {
 	TSV: function (value) {
 		return value
 			.replace(/\\/g, '\\\\')
-			.replace(/\\/g, '\\')
+			.replace(/\'/g, '\\\'')
 			.replace(/\t/g, '\\t')
 			.replace(/\n/g, '\\n');
 	},
@@ -176,6 +176,7 @@ function encodeValue(quote, v, _format, isArray) {
 				return `'${ESCAPE_STRING[format] ? ESCAPE_STRING[format](v, quote) : v}'`;
 			}
 			
+
 			return ESCAPE_STRING[format] ? ESCAPE_STRING[format](v, quote) : v;
 		case 'number':
 			if (isNaN(v)) {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const stream2asynciter = require('stream2asynciter');
 const { URL } = require('url');
 const tsv = require('tsv');
 const uuidv4 = require('uuid/v4');
+const INSERT_FIELDS_MASK = /^INSERT\sINTO\s(.+?)\s*\(((\n|.)+?)\)/i;
 
 
 /**
@@ -176,7 +177,6 @@ function encodeValue(quote, v, _format, isArray) {
 				return `'${ESCAPE_STRING[format] ? ESCAPE_STRING[format](v, quote) : v}'`;
 			}
 			
-
 			return ESCAPE_STRING[format] ? ESCAPE_STRING[format](v, quote) : v;
 		case 'number':
 			if (isNaN(v)) {
@@ -421,7 +421,7 @@ class QueryCursor {
 		}
 		
 		if (isFirstElObject) {
-			let m = query.match(/^INSERT INTO (.+?)\s*\(((\n|.)+?)\)/i);
+			let m = query.match(INSERT_FIELDS_MASK);
 			if (m) {
 				fieldList = m[2].split(',').map(s => s.trim());
 			} else {

--- a/index.js
+++ b/index.js
@@ -420,7 +420,7 @@ class QueryCursor {
 		}
 		
 		if (isFirstElObject) {
-			let m = query.match(/INSERT INTO (.+?) \((.+?)\)/);
+			let m = query.match(/INSERT INTO (.+?) \((.+?)\)/i);
 			if (m) {
 				fieldList = m[2].split(',').map(s => s.trim());
 			} else {

--- a/index.js
+++ b/index.js
@@ -497,15 +497,7 @@ class QueryCursor {
 			//   when passed in the request.
 			Object.keys(data.params).forEach(k => {
 
-				let value = data.params[k].toString();
-
-				if (Array.isArray(data.params[k])) {
-					value = '[' + value + ']'
-				} 
-				else {
-					const str = JSON.stringify(value);
-					value = str.substring(1,str.length-1);
-				}
+				let value = encodeValue(false, data.params[k], 'TabSeparated');
 
 				url.searchParams.append(
 					`param_${k}`, value

--- a/index.js
+++ b/index.js
@@ -421,7 +421,7 @@ class QueryCursor {
 		}
 		
 		if (isFirstElObject) {
-			let m = query.match(/INSERT INTO (.+?) \((.+?)\)/i);
+			let m = query.match(/^INSERT INTO (.+?)\s*\(((\n|.)+?)\)/i);
 			if (m) {
 				fieldList = m[2].split(',').map(s => s.trim());
 			} else {

--- a/test/test.js
+++ b/test/test.js
@@ -515,7 +515,8 @@ describe('queries', () => {
 				str String,
 				arr Array(String),
 				arr2 Array(Date),
-				arr3 Array(UInt8)
+				arr3 Array(UInt8),
+				id1 UUID
 			) ENGINE=MergeTree(date, date, 8192)
 		`).toPromise();
 		expect(r).to.be.ok();
@@ -526,7 +527,8 @@ describe('queries', () => {
 				str: 'Вам, проживающим за оргией оргию,',
 				arr: [],
 				arr2: ['1985-01-02', '1985-01-03'],
-				arr3: [1,2,3,4,5]
+				arr3: [1,2,3,4,5],
+				id1: '102a05cb-8aaf-4f11-a442-20c3558e4384'
 			},
 			
 			{
@@ -534,12 +536,15 @@ describe('queries', () => {
 				str: 'It\'s apostrophe test.',
 				arr: ['5670000000', 'asdas dasf. It\'s apostrophe test.'],
 				arr2: ['1985-02-02'],
-				arr3: []
+				arr3: [],
+				id1: 'c2103985-9a1e-4f4a-b288-b292b5209de1'
 			}
 		];
 		
 		const r2 = await clickhouse.insert(
-			'insert into test_array (date, str, arr, arr2, arr3)',
+			`insert into test_array 
+			(date, str, arr, arr2, 
+			 arr3, id1)`,
 			rows
 		).toPromise();
 		expect(r2).to.be.ok();

--- a/test/test.js
+++ b/test/test.js
@@ -713,8 +713,11 @@ describe('queries', () => {
 			str_value2 String, 
 			date_value Date, 
 			date_time_value DateTime, 
-			decimal_value Decimal(10,4) 
-			) ENGINE=Memory`).toPromise();
+			decimal_value Decimal(10,4),
+			arr Array(String),
+			arr2 Array(Date),
+			arr3 Array(UInt32)
+		) ENGINE=Memory`).toPromise();
 		expect(result1).to.be.ok();
 		
 		const row = {
@@ -724,9 +727,14 @@ describe('queries', () => {
 			date_value: '2022-08-18',
 			date_time_value: '2022-08-18 19:07:00',
 			decimal_value: 1234.678,
+			arr: ['asdfasdf', 'It\'s apostrophe test'],
+			arr2: ['2022-01-01', '2022-10-10'],
+			arr3: [12345, 54321],
 		};
-		const result2 = await clickhouse.insert(`INSERT INTO test_par_temp (int_value, str_value1, str_value2, date_value, date_time_value,	decimal_value)
-			VALUES ({int_value:UInt32}, {str_value1:String}, {str_value2:String}, {date_value:Date}, {date_time_value:DateTime}, {decimal_value: Decimal(10,4)})`, 
+		const result2 = await clickhouse.insert(`INSERT INTO test_par_temp (int_value, str_value1, str_value2, date_value, date_time_value,	decimal_value,
+			arr, arr2, arr3)
+			VALUES ({int_value:UInt32}, {str_value1:String}, {str_value2:String}, {date_value:Date}, {date_time_value:DateTime}, {decimal_value: Decimal(10,4)},
+			{arr:Array(String)},{arr2:Array(Date)},{arr3:Array(UInt32)})`, 
 			{params: {
 				...row,
 				decimal_value: row.decimal_value.toFixed(4)

--- a/test/test.js
+++ b/test/test.js
@@ -539,7 +539,7 @@ describe('queries', () => {
 		];
 		
 		const r2 = await clickhouse.insert(
-			'INSERT INTO test_array (date, str, arr, arr2, arr3)',
+			'insert into test_array (date, str, arr, arr2, arr3)',
 			rows
 		).toPromise();
 		expect(r2).to.be.ok();

--- a/test/test.js
+++ b/test/test.js
@@ -525,15 +525,15 @@ describe('queries', () => {
 				date: '2018-01-01',
 				str: 'Вам, проживающим за оргией оргию,',
 				arr: [],
-				arr2: ['1915-01-02', '1915-01-03'],
+				arr2: ['1985-01-02', '1985-01-03'],
 				arr3: [1,2,3,4,5]
 			},
 			
 			{
 				date: '2018-02-01',
-				str: 'имеющим ванную и теплый клозет!',
-				arr: ['5670000000', 'asdas dasf'],
-				arr2: ['1915-02-02'],
+				str: 'It\'s apostrophe test.',
+				arr: ['5670000000', 'asdas dasf. It\'s apostrophe test.'],
+				arr2: ['1985-02-02'],
 				arr3: []
 			}
 		];
@@ -543,6 +543,8 @@ describe('queries', () => {
 			rows
 		).toPromise();
 		expect(r2).to.be.ok();
+		const r3 = await clickhouse.query('SELECT * FROM test_array ORDER BY date').toPromise();		
+		expect(r3).to.eql(rows);
 	});
 
 	it('insert field as raw string', async () => {
@@ -562,7 +564,7 @@ describe('queries', () => {
 		
 		const rows = [
 			'(\'2018-01-01 10:00:00\',\'Вам, проживающим за оргией оргию,\',[],[\'1915-01-02 10:00:00\',\'1915-01-03 10:00:00\'],[1,2,3,4,5],unhex(\'60ed56e75bb93bd353267faa\'))',
-			'(\'2018-02-01 10:00:00\',\'имеющим ванную и теплый клозет!\',[\'5670000000\',\'asdas dasf\'],[\'1915-02-02 10:00:00\'],[],unhex(\'60ed56f4a88cd5dcb249d959\'))'
+			'(\'2018-02-01 10:00:00\',\'имеющим ванную и теплый клозет! It\'\'s apostrophe test.\',[\'5670000000\',\'asdas dasf\'],[\'1915-02-02 10:00:00\'],[],unhex(\'60ed56f4a88cd5dcb249d959\'))'
 		];
 		
 		const r2 = await clickhouse.insert(


### PR DESCRIPTION
1) compare result of insertion in test in case of array of objects as data (failed before modifications)
2) lower case "insert" now possible in case of array of objects as data (issue 130)
3) mask apostrophe in case of array of objects as data (issue 124)
4) mask apostrophe (and others) in parameters in common  way (function encodeValue instead of JSON.stringify)
5) test arrays as parameters
6) \n in "insert" sql text in case of array of objects as data
7) added test for insert select. In this case function _getBodyForInsert is called, that is not necessary, but that brakes nothing (test to be so in future). 

There is switch on 'values' in sql ignoring cases of 'Some values' in strings, comments and so on. I prefer direct case of execution with extra parameters options, but it is more complex issue.