### PR TITLE
JSONEachRow

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,32 @@ insert array of objects:
 ```
 ***
 
+insert with format JSONEachRow:
+```javascript
+
+// rows - array of objects as in previous example
+		
+		await clickhouse.insert(
+			`INSERT INTO test_array 
+			(*) FORMAT JSONEachRow`,
+			rows
+		).toPromise();
+
+// or with stream
+
+		const stream = await clickhouse.insert(
+			`insert into test_array 
+			(*) FORMAT JSONEachRow`
+		).stream();
+
+		for (const row of rows){
+			stream.writeRow(row);
+		}
+		await stream.exec();
+
+```
+***
+
 Parameterized Values:
 ```javascript
 const rows = await clickhouse.query(

--- a/index.js
+++ b/index.js
@@ -31,7 +31,6 @@ const SEPARATORS = {
 
 const ALIASES = {
 	TabSeparated: "TSV",
-	JSONEachRow: "jsonEachRow"
 };
 
 var ESCAPE_STRING = {
@@ -67,7 +66,7 @@ const PORT = 8123;
 const DATABASE = 'default';
 
 const FORMAT_NAMES = {
-	JSONEachRow: 'jsonEachRow',
+	JSONEachRow: 'JSONEachRow',
 	JSON: 'json',
 	TSV: 'tsv',
 	CSV: 'csv'


### PR DESCRIPTION
support JSONEachRow format added. This format allow insert arrays of objects or write objects to insert stream in cases when field list can not be parsed.

i.e. "insert into test_array (*)".

TabSeparated is still default format, hence you should set format:

insert into test_array (*) FORMAT JSONEachRow