### PR TITLE
Fix insert to nullable column

### DIFF
--- a/index.js
+++ b/index.js
@@ -989,7 +989,7 @@ class ClickHouse {
 	static mapRowAsObject(fieldList, row) {
 		return fieldList
 			.map(f => {
-				return encodeValue(false, row[f] != null ? row[f] : '', 'TabSeparated');
+				return encodeValue(false, row[f] != null || row[f] === null ? row[f] : '', 'TabSeparated');
 			})
 			.join('\t');
 	}


### PR DESCRIPTION
Insert into Nullable(UUID) column was failed with body parse exceptions if at leat one row contains null value.

Explicit `null` value must be escaped to `\N`, not to empty string.